### PR TITLE
Match "down" on insufficient resources test

### DIFF
--- a/wats/dats_instance_reporting_test.go
+++ b/wats/dats_instance_reporting_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Getting instance information", func() {
 		BeforeEach(func() {
 			context.SetRunawayQuota()
 			scale := cf.Cf("scale", appName, "-m", EXCEED_CELL_MEMORY, "-f")
-			Eventually(scale, CF_PUSH_TIMEOUT).Should(Say("insufficient resources"))
+			Eventually(scale, CF_PUSH_TIMEOUT).Should(Say("insufficient resources|down"))
 			scale.Kill()
 		})
 


### PR DESCRIPTION
This change is analogous to the change in the DATs at https://github.com/cloudfoundry-incubator/diego-acceptance-tests/commit/2304d3e7670893ba22b59f2eb2130f384d25c0a8, related to Diego story https://www.pivotaltracker.com/story/show/110347652.